### PR TITLE
Add omero-upload

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,6 @@
 	path = omero-webtest
 	url = git://github.com/openmicroscopy/omero-webtest
 	branch = master
+[submodule "omero-upload"]
+	path = omero-upload
+	url = git://github.com/ome/omero-upload/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
+---
 language: python
+python: 2.7
 sudo: required
 services:
   - docker
+
+matrix:
+  allow_failures:
+  # The build is currently failing to download oracle-java8-installer
+  - REPO=rOMERO-gateway STAGE=lib
 
 env:
 - REPO=minimal-omero-client STAGE=lib
@@ -15,6 +22,7 @@ env:
 - REPO=omero-metadata STAGE=cli PLUGIN=metadata
 - REPO=omero-parade STAGE=app
 - REPO=omero-prometheus-tools STAGE=lib
+- REPO=omero-upload STAGE=cli
 - REPO=omero-weberror STAGE=app
 - REPO=omero-webtest STAGE=app
 - REPO=rOMERO-gateway STAGE=lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 - REPO=omero-metadata STAGE=cli PLUGIN=metadata
 - REPO=omero-parade STAGE=app
 - REPO=omero-prometheus-tools STAGE=lib
-- REPO=omero-upload STAGE=cli
+- REPO=omero-upload STAGE=cli PLUGIN=upload
 - REPO=omero-weberror STAGE=app
 - REPO=omero-webtest STAGE=app
 - REPO=rOMERO-gateway STAGE=lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 matrix:
   allow_failures:
   # The build is currently failing to download oracle-java8-installer
-  - REPO=rOMERO-gateway STAGE=lib
+  - env: REPO=rOMERO-gateway STAGE=lib
 
 env:
 - REPO=minimal-omero-client STAGE=lib


### PR DESCRIPTION
Also fixes Travis CI to specify Python 2.7 in the configuration file and add `rOMERO-gateway` to the allowed failures until the `oracle8-jdk-installer` issue is resolved

With this meta-repository back to green, we should be in a good place to pre-test OMERO 5.5 against all downstream applications and libraries if we wish so.