### PR TITLE
adjust build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,7 @@ env:
 - REPO=scripts STAGE=scripts
 
 script:
-- |
-  if [ "$REPO" == "omero-iviewer" ]; then
-      cd $REPO && mkdir .omero && cp -r ../omero-test-infra/. .omero && .omero/docker $STAGE
-  else
-      cd $REPO &&  ln -s ../omero-test-infra .omero && .omero/docker $STAGE
-  fi
-
+- cd $REPO && cp -r ../omero-test-infra .omero && .omero/docker $STAGE
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,13 @@ env:
 - REPO=scripts STAGE=scripts
 
 script:
-- cd $REPO && ln -s ../omero-test-infra .omero && .omero/docker $STAGE
+- |
+  if [ "$REPO" == "omero-iviewer" ]; then
+      cd $REPO && mkdir .omero && cp -r ../omero-test-infra/. .omero && .omero/docker $STAGE
+  else
+      cd $REPO &&  ln -s ../omero-test-infra .omero && .omero/docker $STAGE
+  fi
+
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Adjust build so we can run the omero-iviewer tests. 
The symlink does not work when running the unit tests of iviewer. 
This is not as clean as one would like but it will allow the job to turn green
This can be reverted when we have time to revisit the infra for iviewer's tests

Without this PR, the iviewer failure when running the tests
```
no such file or directory, stat '/omero-iviewer/.omero'] {
     [exec]   errno: -2,
     [exec]   code: 'ENOENT',
     [exec]   syscall: 'stat',
     [exec]   path: '/omero-iviewer/.omero'
```

cc @sbesson 

