### PR TITLE
Update gitmodule branch of minimal-omero-client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "minimal-omero-client"]
 	path = minimal-omero-client
 	url = git://github.com/ome/minimal-omero-client
-	branch = dev_5_4
+	branch = master
 [submodule "scripts"]
 	path = scripts
 	url = git://github.com/ome/scripts


### PR DESCRIPTION
It looks like the tracking branch was still set to `dev_5_4` which caused dependabot to erroneously open #52 